### PR TITLE
Remove direct reference to OSRE vs GSoC

### DIFF
--- a/content/osredocs/forstudents/index.md
+++ b/content/osredocs/forstudents/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Guidelines for Students"
+title: "Guidelines for Summer Students"
 summary:
 authors: [admin,slieggi]
 date: "2022-11-06T00:00:00Z"
@@ -17,11 +17,11 @@ comments: false  # Show comments?
 
 
 
-## How to apply to the OSRE
+## How to apply to the be a contributor to GSoC / OSRE
 
 1. Take a look at [projects](/osre#projects).
 2. Between February 22 and March 19, select projects of interest, contact their mentor(s), and tell them your motivation and send them your resume/CV. You are strongly encouraged to apply to no more than two projects.
-3. Join the slack channel for contributor applicants. Contact [OSRE Admins](mailto:ospo-info-group@ucsc.edu) to request an invitation. Note that we will only review proposals of contributors who have also joined our slack channel by March 20. Use this time to also get to know the project to which you are applying and the members of the project community. You are highly encouraged to ask questions. 
+3. Join the slack channel for contributor applicants. Contact [Org Admins](mailto:ospo-info-group@ucsc.edu) to request an invitation. Note that we will only review proposals of contributors who have also joined our slack channel by March 20. Use this time to also get to know the project to which you are applying and the members of the project community. You are highly encouraged to ask questions. 
 4. Be prepared to provide mentors with some examples of your technical knowledge as an initial step. For instance, mentors may ask you to carry out a technical test or show work you have done in the past to assess your knowledge. This is an important step for ensuring you are proposing something that is beneficial to you, the mentor and the community. We have opportunities for contributors with a wide range of skill levels, so do not worry about "passing" the test - just show what your skill levels are and areas you are interested to grow in.
 5. Once you and the mentor have established your level of proficiency and how it fits within project ideas, you will collaborate on writing the proposal. 
 The mentors will:
@@ -33,20 +33,20 @@ Note that the mentor feedback period will typically run from March 20 to April 3
     - A detailed plan of work with an estimate of the time needed (typically 175 or 375 hours in total). See below for a [suggested template](#suggested-proposal-template).
     - Well defined tasks and their objectives, list of deliverables
     - Note: any committments that could impact the amount of time you can spend on the project.  
-6. Mentors will provide a ranked list of proposals to OSRE Admins. Results are made public on May 4.
+6. Mentors will provide a ranked list of proposals to Org Admins. Results are made public on May 4.
 
 
 {{% callout note %}}  
 IMPORTANT REQUIREMENT FOR ALL ACCEPTED PROPOSALS  
 
-OSRE contributors will be required to provide short weekly status updates. These will help the mentors and the OSRE Admins see that your project is on track. They are also meant to provide a basis for blog posts to be completed by the contributors and highlighted by the organization admins.  
+Summer contributors will be required to provide short weekly status updates. These will help the mentors and the Org Admins see that your project is on track. They are also meant to provide a basis for blog posts to be completed by the contributors and highlighted by the organization admins.  
 
-Mentors and OSRE Admins expect summer contributors to act professionally and respect the mentor's time and efforts. As with any professional setting, it is the responsibility of the contributor/student to inform their mentor if they will be taking any vacations or if they have any other obligation that conflicts with the proposed workplan. Not informing the mentor of these conflicts can result in removal from the program.  
+Mentors and Org Admins expect summer contributors to act professionally and respect the mentor's time and efforts. As with any professional setting, it is the responsibility of the contributor/student to inform their mentor if they will be taking any vacations or if they have any other obligation that conflicts with the proposed workplan. Not informing the mentor of these conflicts can result in removal from the program.  
 
 Contributors will be expected to attend all-hands and other group meetings throughout the program. These meetings will be via zoom and held at various times of day to allow participation for a wide range of time zones.  
 {{% /callout %}}
 
-Do not hesitate to contact  [OSRE Admins](ospo-info-group@ucsc.edu) for further questions.
+Do not hesitate to contact  [Org Admins](ospo-info-group@ucsc.edu) for further questions.
 
 ## Suggested proposal template
 


### PR DESCRIPTION
Realized that this link is supposed to also be on the GSoC application and think it would be confusing if it talked about OSRE and not GSoC. To simplify just referred to everything more generally ("summer contributors") and changed OSRE admin to Org admin.